### PR TITLE
multi-line text support and text&gui fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,9 +133,13 @@ class App(customtkinter.CTk):
         self.device_frame = customtkinter.CTkScrollableFrame(self.device_window, width=280, height=300)
         self.device_frame.pack(pady=10, padx=10, fill="both", expand=True)
 
+        # Bring the window to the top immediately after creation
+        self.device_window.lift()
+
         # Schedule grab_set after the window becomes viewable
         self.after(100, lambda: self.device_window.grab_set())
 
+        # Start the asynchronous scan in a separate thread
         threading.Thread(target=lambda: asyncio.run(self._async_scan_for_printer())).start()
 
 
@@ -206,6 +210,8 @@ class App(customtkinter.CTk):
 
     async def _async_scan_for_printer(self):
         try:
+            self.device_window.lift()
+
             devices = await BleakScanner.discover(timeout=5.0)
 
             filtered = [d for d in devices if d.name]  # Only show named devices
@@ -215,6 +221,7 @@ class App(customtkinter.CTk):
                 return
 
             self.after(0, lambda: self.populate_device_window(filtered))
+            self.after(0, lambda: self.device_window.lift())
 
 
         except Exception as e:

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ class MainTabView(customtkinter.CTkTabview):
         self.print_txt_button = customtkinter.CTkButton(
             master=self.tab("Text Label"),
             text="Print Label",
-            command=lambda: app_reference.btn_print_txt_label(self.textinput.get())
+            command=lambda: app_reference.btn_print_txt_label(self.textinput.get("1.0", customtkinter.END) )
         )
         self.print_txt_button.grid(row=1, column=1, padx=20, pady=20, sticky="ew")
 
@@ -63,7 +63,7 @@ class App(customtkinter.CTk):
         self.device_window = None
         self.device_frame = None
         self.scan_label = None
-        self.geometry("320x500")
+        self.geometry("420x450")
         self.title("LT200B Label Maker")
         self.grid_columnconfigure(0, weight=1)
 
@@ -198,6 +198,8 @@ class App(customtkinter.CTk):
         if not text_value:
             self.safe_alert("Label empty", "The label text is empty. Please provide a label text", level="info")
             return
+
+        text_value = text_value.replace("\r\n", "n").rstrip().lstrip()
 
         try:
             with lt200b.create_text_image(text_value, None, 64) as img:

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ class MainTabView(customtkinter.CTkTabview):
         # Text label
         self.textinput_label = customtkinter.CTkLabel(master=self.tab("Text Label"), text="Text Input")
         self.textinput_label.grid(row=0, column=0, padx=20, pady=10)
-        self.textinput = customtkinter.CTkEntry(master=self.tab("Text Label"))
+        self.textinput = customtkinter.CTkTextbox(master=self.tab("Text Label"), width=240, height=80, wrap="none")
         self.textinput.grid(row=0, column=1, padx=20, pady=20, sticky="ew")
         self.print_txt_button = customtkinter.CTkButton(
             master=self.tab("Text Label"),

--- a/utils/lt200b.py
+++ b/utils/lt200b.py
@@ -7,12 +7,10 @@ def create_text_image(text, font_path, font_size):
     else:
         font = ImageFont.load_default(font_size)
 
-    with Image.new("RGB", (1, 1), "white") as temp_img:
-        temp_draw = ImageDraw.Draw(temp_img)
-        text_width = temp_draw.textlength(text, font=font)
+    text_width, text_height = textsize(text, font)
 
     img_width = int(text_width)
-    img_height = 64
+    img_height = int(text_height)
 
     img = Image.new("RGB", (img_width, img_height), "white")
     draw = ImageDraw.Draw(img)
@@ -21,6 +19,11 @@ def create_text_image(text, font_path, font_size):
 
     return img
 
+def textsize(text, font):
+    im = Image.new(mode="P", size=(0, 0))
+    draw = ImageDraw.Draw(im)
+    _, _, width, height = draw.textbbox((0, 0), text=text, font=font)
+    return width, height
 
 async def print_image(address, job):
     async with BleakClient(address) as client:

--- a/utils/lt200b.py
+++ b/utils/lt200b.py
@@ -15,7 +15,7 @@ def create_text_image(text, font_path, font_size):
     img = Image.new("RGB", (img_width, img_height), "white")
     draw = ImageDraw.Draw(img)
 
-    draw.text((0, 32), text, font=font, fill="black", anchor="lm")
+    draw.multiline_text((0, img_height / 2), text, font=font, fill="black", anchor="lm") # align middle left anchored in the middle
 
     return img
 


### PR DESCRIPTION
following fixes are included:
- proper text size detection avoid cutting of lower strokes for g, p, and q
- scanning window stays on top while scanning

following new features are included:
- multi-line text printing
- text cleanup (lstrip(0 & rstrip(), and removal of Windows line-breaks as `\r` prints an unwanted character)

known issue:
- image print tab layout not centered